### PR TITLE
Typo "**\_Resetstkoflw**"→”**\_resetstkoflw**”

### DIFF
--- a/windows-driver-docs-pr/devtest/28615-must-call-resetstkoflw-in-except-block.md
+++ b/windows-driver-docs-pr/devtest/28615-must-call-resetstkoflw-in-except-block.md
@@ -1,6 +1,6 @@
 ---
 title: C28615
-description: _ _Try ブロックで _alloca を呼び出すときに、_ _except() ブロックで _resetstkoflw を呼び出す警告 C28615 する必要があります。 Catch() ブロック内から _resetstkoflw を呼び出さないでください。
+description: __Try ブロックで _alloca を呼び出すときに、__except() ブロックで _resetstkoflw を呼び出す警告 C28615 する必要があります。 Catch() ブロック内から _resetstkoflw を呼び出さないでください。
 ms.assetid: bccfc846-58b9-4c20-bbe7-383ecf836165
 ms.date: 04/20/2017
 ms.localizationpriority: medium
@@ -24,7 +24,7 @@ C28615 を警告します。呼び出す必要があります\_で resetstkoflw�
 
 呼び出す必要があります **\_resetstkoflw**現在のスタック ポインターがスタック上の 3 番目のページを超えるアドレスを指す場合。 ガード ページのスタック ポインターが指している現在のページから意味をなさない (または後で) ためにです。
 
-**\_Resetstkoflw**構造化例外ハンドラーのフィルター式とは構造化例外ハンドラーのフィルター式から呼び出される関数から、関数を呼び出すことはできません。
+**\_resetstkoflw**構造化例外ハンドラーのフィルター式とは構造化例外ハンドラーのフィルター式から呼び出される関数から、関数を呼び出すことはできません。
 
 ### <a name="span-idexamplesspanspan-idexamplesspanexamples"></a><span id="examples"></span><span id="EXAMPLES"></span>例
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/windows-hardware/drivers/devtest/28615-must-call-resetstkoflw-in-except-block