### PR TITLE
Typo "_ _Try"→"\_\_Try"

### DIFF
--- a/windows-driver-docs-pr/devtest/prefast-for-drivers-warnings.md
+++ b/windows-driver-docs-pr/devtest/prefast-for-drivers-warnings.md
@@ -257,7 +257,7 @@ ms.locfileid: "67358269"
 </tr>
 <tr class="odd">
 <td align="left"><p><a href="28615-must-call-resetstkoflw-in-except-block.md" data-raw-source="[C28615](28615-must-call-resetstkoflw-in-except-block.md)">C28615</a></p></td>
-<td align="left"><p>C28615 を警告します。_ _Try ブロックで _alloca を呼び出すときに、_ _except() ブロックで _resetstkoflw を呼び出す必要があります。 Catch() ブロック内から _resetstkoflw を呼び出さないでください。</p></td>
+<td align="left"><p>C28615 を警告します。\_\_Try ブロックで _alloca を呼び出すときに、\_\_except() ブロックで _resetstkoflw を呼び出す必要があります。 Catch() ブロック内から _resetstkoflw を呼び出さないでください。</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p><a href="28616-multithreaded-av-condition.md" data-raw-source="[C28616](28616-multithreaded-av-condition.md)">C28616</a></p></td>


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/windows-hardware/drivers/devtest/prefast-for-drivers-warnings